### PR TITLE
.ci/project-dependencies.yaml: remove Drools / Kogito mapping

### DIFF
--- a/.ci/project-dependencies.yaml
+++ b/.ci/project-dependencies.yaml
@@ -1,67 +1,20 @@
 version: "2.1"
 dependencies:
   - project: kiegroup/drools
-    mapping:
-      dependencies:
-        default:
-          - source: (\d*)\.(.*)
-            targetExpression: "process.env.GITHUB_BASE_REF.replace(/(\\d*)\\.(.*)/g, (m, n1, n2) => `${+n1-7}.${n2}`)"
-      dependant:
-        default:
-          - source: (\d*)\.(.*)
-            targetExpression: "process.env.GITHUB_BASE_REF.replace(/(\\d*)\\.(.*)/g, (m, n1, n2) => `${+n1+7}.${n2}`)"
-      exclude:
-        - kiegroup/kie-jpmml-integration
 
   - project: kiegroup/kogito-runtimes
     dependencies:
       - project: kiegroup/drools
-    mapping:
-      dependencies:
-        default:
-          - source: (\d*)\.(.*)
-            targetExpression: "process.env.GITHUB_BASE_REF.replace(/(\\d*)\\.(.*)/g, (m, n1, n2) => `${+n1+7}.${n2}`)"
-      dependant:
-        default:
-          - source: (\d*)\.(.*)
-            targetExpression: "process.env.GITHUB_BASE_REF.replace(/(\\d*)\\.(.*)/g, (m, n1, n2) => `${+n1-7}.${n2}`)"
-      exclude:
-        - kiegroup/kogito-examples
-        - kiegroup/kogito-apps
-  
+
   - project: kiegroup/kogito-apps
     dependencies:
       - project: kiegroup/kogito-runtimes
-    mapping:
-      dependencies:
-        default:
-          - source: (\d*)\.(.*)
-            targetExpression: "process.env.GITHUB_BASE_REF.replace(/(\\d*)\\.(.*)/g, (m, n1, n2) => `${+n1+7}.${n2}`)"
-      dependant:
-        default:
-          - source: (\d*)\.(.*)
-            targetExpression: "process.env.GITHUB_BASE_REF.replace(/(\\d*)\\.(.*)/g, (m, n1, n2) => `${+n1-7}.${n2}`)"
-      exclude:
-        - kiegroup/kogito-examples
-        - kiegroup/kogito-runtimes
 
   - project: kiegroup/kogito-examples
     dependencies:
       - project: kiegroup/kogito-runtimes
       - project: kiegroup/kogito-apps
-    mapping:
-      dependencies:
-        default:
-          - source: (\d*)\.(.*)
-            targetExpression: "process.env.GITHUB_BASE_REF.replace(/(\\d*)\\.(.*)/g, (m, n1, n2) => `${+n1+7}.${n2}`)"
-      dependant:
-        default:
-          - source: (\d*)\.(.*)
-            targetExpression: "process.env.GITHUB_BASE_REF.replace(/(\\d*)\\.(.*)/g, (m, n1, n2) => `${+n1-7}.${n2}`)"
-      exclude:
-        - kiegroup/kogito-apps
-        - kiegroup/kogito-runtimes
+
   - project: kiegroup/kie-jpmml-integration
     dependencies:
       - project: kiegroup/drools
-    # no mapping needed


### PR DESCRIPTION
This mapping is not required anymore as Drools and Kogito are now synced in the same branch/version. This was needed before because the branches used to be Kogito 1.x and Drools 8.x