### PR TITLE
[1.13.x][BXMSPROD-2209] move prod nightly to use rhel8

### DIFF
--- a/.ci/jenkins/Jenkinsfile.prod.nightly
+++ b/.ci/jenkins/Jenkinsfile.prod.nightly
@@ -2,7 +2,7 @@
 
 pipeline {
     agent {
-        label 'kie-rhel7 && kie-mem24g && !built-in'
+        label 'kie-rhel8 && kie-mem24g && !built-in'
     }
     tools {
         maven 'kie-maven-3.8.6'


### PR DESCRIPTION
Related PRs:
- https://github.com/kiegroup/kogito-pipelines/pull/45
- https://github.com/kiegroup/kogito-pipelines/pull/46