### PR TITLE
changing minimal maven version for MAIN NIGHTLIES

### DIFF
--- a/.ci/jenkins/config/branch.yaml
+++ b/.ci/jenkins/config/branch.yaml
@@ -110,6 +110,6 @@ jenkins:
   email_creds_id: KOGITO_CI_EMAIL_TO
   default_tools:
     jdk: kie-jdk17
-    maven: kie-maven-3.9.3
+    maven: kie-maven-3.9.6
     sonar_jdk: kie-jdk17
   jobs_definition_file: .ci/jenkins/dsl/jobs.groovy


### PR DESCRIPTION
This should fix the Drools and deploy nightly job failure KIE/job/drools/job/main/job/nightly/job/drools.build-and-deploy/