### PR TITLE
SRVLOGIC-631: Update paths to image manifest YAML files

### DIFF
--- a/.ci/jenkins/Jenkinsfile.prod.nightly
+++ b/.ci/jenkins/Jenkinsfile.prod.nightly
@@ -354,6 +354,7 @@ def buildOperator(String descriptorFile, String nightlyBranchName, String operat
         sh """sed -i "s/branch:.*/branch: ${nightlyBranchName}/g" ${descriptorFile}"""
         def reference = sh(returnStdout: true, script: "cd ${operatorCodeRepository};git rev-parse HEAD").trim()
         sh """sed -i "s/ref:.*/ref: ${reference}/g" ${descriptorFile}"""
+        sh """sed -i "s/ version:.*/ version: ${env.ARTIFACTS_VERSION}/g" ${descriptorFile}"""
         println "Diff of ${descriptorFile} after replacing branch name and ref"
         sh "git diff ${descriptorFile}"
 

--- a/.ci/jenkins/Jenkinsfile.prod.nightly
+++ b/.ci/jenkins/Jenkinsfile.prod.nightly
@@ -98,7 +98,7 @@ pipeline {
                     env.NIGHTLY_BRANCH_NAME = 'openshift-serverless-nightly-rhel-8'
                     env.ARTIFACTS_VERSION = "${env.PRODUCT_VERSION}.redhat-${env.DATE_TIME_SUFFIX}"
                     env.M2_FOLDER = '/home/jenkins/.m2/repository'
-                    env.IMAGES_REPOSITORY_PATH = "${env.WORKSPACE}/bc/kubesmarts_kie-tools"
+                    env.IMAGES_REPOSITORY_PATH = "${env.WORKSPACE}/bc/kubesmarts_osl-images"
                     env.OPERATOR_DESCRIPTOR_REPOSITORY_PATH = "${env.WORKSPACE}/bc/kubesmarts_osl-images"
                     env.OPERATOR_CODE_REPOSITORY_PATH= "${env.IMAGES_REPOSITORY_PATH}"
                     env.SLEEP_TIME = '30' // required as cekit-cache command fails if many invocations at the same time
@@ -135,7 +135,7 @@ pipeline {
                         script {
                             sleep(Integer.parseInt(env.SLEEP_TIME) * 0)
 
-                            def descriptorFilePath = 'packages/osl-data-index-ephemeral-image/generated/logic-data-index-ephemeral-rhel8-image.yaml'
+                            def descriptorFilePath = 'images-dist/logic-data-index-ephemeral-rhel8-image.yaml'
                             // Map with artifact path required in image module.yaml
                             def artifacts = ["${env.M2_FOLDER}/org/kie/kogito/data-index-service-inmemory/${env.ARTIFACTS_VERSION}/data-index-service-inmemory-${env.ARTIFACTS_VERSION}-image-build.zip": "data-index-service-inmemory-image-build.zip"]
 
@@ -148,7 +148,7 @@ pipeline {
                         script {
                             sleep(Integer.parseInt(env.SLEEP_TIME) * 1)
 
-                            def descriptorFilePath = 'packages/osl-data-index-postgresql-image/generated/logic-data-index-postgresql-rhel8-image.yaml'
+                            def descriptorFilePath = 'images-dist/logic-data-index-postgresql-rhel8-image.yaml'
                             // Map with artifact path required in image module.yaml
                             def artifacts = ["${env.M2_FOLDER}/org/kie/kogito/data-index-service-postgresql/${env.ARTIFACTS_VERSION}/data-index-service-postgresql-${env.ARTIFACTS_VERSION}-image-build.zip": "data-index-service-postgresql-image-build.zip"]
 
@@ -161,7 +161,7 @@ pipeline {
                         script {
                             sleep(Integer.parseInt(env.SLEEP_TIME) * 2)
 
-                            def descriptorFilePath = 'packages/osl-jobs-service-ephemeral-image/generated/logic-jobs-service-ephemeral-rhel8-image.yaml'
+                            def descriptorFilePath = 'images-dist/logic-jobs-service-ephemeral-rhel8-image.yaml'
                             // Map with artifact path required in image module.yaml
                             def artifacts = ["${env.M2_FOLDER}/org/kie/kogito/jobs-service-inmemory/${env.ARTIFACTS_VERSION}/jobs-service-inmemory-${env.ARTIFACTS_VERSION}-image-build.zip": "jobs-service-inmemory-image-build.zip"]
 
@@ -174,7 +174,7 @@ pipeline {
                         script {
                             sleep(Integer.parseInt(env.SLEEP_TIME) * 3)
 
-                            def descriptorFilePath = 'packages/osl-jobs-service-postgresql-image/generated/logic-jobs-service-postgresql-rhel8-image.yaml'
+                            def descriptorFilePath = 'images-dist/logic-jobs-service-postgresql-rhel8-image.yaml'
                             // Map with artifact path required in image module.yaml
                             def artifacts = ["${env.M2_FOLDER}/org/kie/kogito/jobs-service-postgresql/${env.ARTIFACTS_VERSION}/jobs-service-postgresql-${env.ARTIFACTS_VERSION}-image-build.zip": "jobs-service-postgresql-image-build.zip"]
 
@@ -187,7 +187,7 @@ pipeline {
                         script {
                             sleep(Integer.parseInt(env.SLEEP_TIME) * 4)
 
-                            def descriptorFilePath = 'packages/osl-swf-builder-image/generated/logic-swf-builder-rhel8-image.yaml'
+                            def descriptorFilePath = 'images-dist/osl-swf-builder-image/generated/logic-swf-builder-rhel8-image.yaml'
                             // Map with artifact path required in image module.yaml
                             def artifacts = ["${env.M2_FOLDER}/com/redhat/osl/osl-builder-quarkus-app/${env.ARTIFACTS_VERSION}/osl-builder-quarkus-app-${env.ARTIFACTS_VERSION}-image-build.zip": "kogito-builder-quarkus-app-image-build.zip",
                                             "${env.M2_FOLDER}/com/redhat/osl/osl-builder-maven-repository/${env.ARTIFACTS_VERSION}/osl-builder-maven-repository-${env.ARTIFACTS_VERSION}-image-build.zip": "kogito-builder-maven-repository-image-build.zip"
@@ -202,7 +202,7 @@ pipeline {
                         script {
                             sleep(Integer.parseInt(env.SLEEP_TIME) * 5)
 
-                            def descriptorFilePath = 'packages/osl-swf-devmode-image/generated/logic-swf-devmode-rhel8-image.yaml'
+                            def descriptorFilePath = 'images-dist/logic-swf-devmode-rhel8-image.yaml'
                             // Map with artifact path required in image module.yaml
                             def artifacts = ["${env.M2_FOLDER}/com/redhat/osl/osl-devmode-quarkus-app/${env.ARTIFACTS_VERSION}/osl-devmode-quarkus-app-${env.ARTIFACTS_VERSION}-image-build.zip": "kogito-devmode-quarkus-app-image-build.zip",
                                             "${env.M2_FOLDER}/com/redhat/osl/osl-devmode-maven-repository/${env.ARTIFACTS_VERSION}/osl-devmode-maven-repository-${env.ARTIFACTS_VERSION}-image-build.zip": "kogito-devmode-maven-repository-image-build.zip"
@@ -217,7 +217,7 @@ pipeline {
                         script {
                             sleep(Integer.parseInt(env.SLEEP_TIME) * 6)
 
-                            def descriptorFilePath = 'packages/osl-db-migrator-tool-image/generated/logic-db-migrator-tool-rhel8-image.yaml'
+                            def descriptorFilePath = 'images-dist/logic-db-migrator-tool-rhel8-image.yaml'
                             // Map with artifact path required in image module.yaml
                             def artifacts = ["${env.M2_FOLDER}/org/kie/kogito/kogito-db-migrator-tool/${env.ARTIFACTS_VERSION}/kogito-db-migrator-tool-${env.ARTIFACTS_VERSION}-image-build.zip": "db-migrator-tool-image-build.zip"]
 


### PR DESCRIPTION
Now points to `images-dist/manifest.yaml`  as we have moved to build all images from https://github.com/kubesmarts/osl-images/