### PR TITLE
SRVLOGIC-582: Use descriptorFilePath to modify image manifests

### DIFF
--- a/.ci/jenkins/Jenkinsfile.prod.nightly
+++ b/.ci/jenkins/Jenkinsfile.prod.nightly
@@ -379,10 +379,10 @@ def buildImage(String imageName, String descriptorFilePath, String nightlyBranch
         println "Building image ${imageName}"
 
         def descriptorFile = descriptorFilePath.substring(descriptorFilePath.lastIndexOf('/') + 1, descriptorFilePath.size())
-        sh """sed -i "s/branch:.*/branch: ${nightlyBranchName}/g" ${descriptorFilePath}"""
-        sh """sed -i "s/999-20250511-local/${env.ARTIFACTS_VERSION}/g" ${descriptorFilePath}"""
-        println "Diff of ${descriptorFilePath} after replacing branch name"
-        sh "git diff ${descriptorFilePath}"
+        sh """sed -i "s/branch:.*/branch: ${nightlyBranchName}/g" ${descriptorFile}"""
+        sh """sed -i "s/999-20250511-local/${env.ARTIFACTS_VERSION}/g" ${descriptorFile}"""
+        println "Diff of ${descriptorFile} after replacing branch name and org.kie.kogito.version"
+        sh "git diff ${descriptorFile}"
 
         println 'Using cekit version'
         util.runWithPythonVirtualEnv('cekit --version', 'cekit')


### PR DESCRIPTION
After the latest switch to use `osl-images/images-dist` we have some discrepancies in the `buildImage` function.

The pipeline step does this:
`cp -rp /home/jenkins/workspace/PROD_kogito.nightly_main/bc/kubesmarts_osl-images/images-dist /home/jenkins/workspace/PROD_kogito.nightly_main/data-index-ephemeral_repo`

Which results in following directory: `.../data-index-ephemeral_repo/images-dist/...` 

Later in the function we do `def descriptorFile = descriptorFilePath.substring(descriptorFilePath.lastIndexOf('/') + 1, descriptorFilePath.size())` which take `images-dist/logic-data-index-ephemeral-rhel8-image.yaml` and sets `logic-data-index-ephemeral-rhel8-image.yaml` to `descriptorFile`

However, the working directory is `data-index-ephemeral_repo` so the follow up `sed` commands will work with reference.

Later in the cekitBuildCmd definition we also use `def cekitBuildCmd = "cekit --redhat --descriptor ${descriptorFile} build ${overrides} osbs --user rhba-osbs-builder -y"` but I am not sure if this needs changing as this seems to work (based on latest nightly logs)


This PR also adds `sh """sed -i "s/999-20250511-local/${env.ARTIFACTS_VERSION}/g" ${descriptorFilePath}"""` to replace hardcoded version in `kubesmarts/osl-images` e.g. [DI Ephemeral image manifest](https://github.com/kubesmarts/osl-images/blob/a05faa03c05a54b2101b9ffd1644329530509e7e/images-dist/logic-data-index-ephemeral-rhel8-image.yaml#L40)