### PR TITLE
SRVLOGIC-632: Move builds from kiegroup to kubesmarts - nightly

### DIFF
--- a/.ci/nightly-build-config.yaml
+++ b/.ci/nightly-build-config.yaml
@@ -44,7 +44,7 @@ build:
         ${{ env.PME_CMD }} ${{ env.PME_ALIGNMENT_PARAMS_kiegroup_kogito_examples }}
         bash -c "set -e ; set -o pipefail ; ${{ env.REMOVE_MODULES }} ; ${{ env.PME_BUILD_SCRIPT_kiegroup_kogito_examples }} ${{ env.BUILD_MVN_OPTS }} | tee ${{ env.WORKSPACE }}/kogito_examples.maven.log"
 
-  - project: kiegroup/kie-tools
+  - project: kubesmarts/kie-tools
     build-command:
       downstream: |
         ${{ env.PME_CMD }} ${{ env.PME_ALIGNMENT_PARAMS_kiegroup_kie_tools }}


### PR DESCRIPTION
https://issues.redhat.com/browse/SRVLOGIC-632

Not sure if this is everything and correct. Let me know please.