### PR TITLE
SRVLOGIC-532: Fix nightly project dependencies

### DIFF
--- a/.ci/nightly-build-config.yaml
+++ b/.ci/nightly-build-config.yaml
@@ -61,8 +61,3 @@ build:
         echo "NIGHTLY_DEPLOY_FOLDER=${{ env.NIGHTLY_DEPLOY_FOLDER }}"
         ${{ env.PME_CMD }} ${{ env.PME_ALIGNMENT_PARAMS_kubesmarts_osl_images }}
         bash -c "set -o pipefail ; ${{ env.PME_BUILD_SCRIPT_kubesmarts_osl_images }} ${{ env.BUILD_MVN_OPTS }} | tee ${{ env.WORKSPACE }}/kogito_images.maven.log"
-
-  - project: kubesmarts/kie-tools
-    build-command:
-      downstream: |
-        echo "Cloned kubesmarts/kie-tools repository for building the images"

--- a/.ci/nightly-project-dependencies.yaml
+++ b/.ci/nightly-project-dependencies.yaml
@@ -23,7 +23,3 @@ dependencies:
   - project: kubesmarts/osl-images
     dependencies:
       - project: kubesmarts/kie-tools
-
-  - project: kubesmarts/kie-tools
-    dependencies:
-      - project: kubesmarts/osl-images


### PR DESCRIPTION
https://issues.redhat.com/browse/SRVLOGIC-632

seems like the previous config introduced a cycle, not sure what is the best solution but made the last build depend on all Java parts.

Maybe we need to just remove the last part? Or have the kubesmarts/kie-tools only once?