### PR TITLE
SRVLOGIC-657:  Include KN Workflow plugin binaries in nightly product build - round 5

### DIFF
--- a/.ci/jenkins/Jenkinsfile.prod.nightly
+++ b/.ci/jenkins/Jenkinsfile.prod.nightly
@@ -4,7 +4,7 @@ import org.kie.jenkins.MavenCommand
 
 pipeline {
     agent {
-        label 'RHEL9 && podman && mem16G && !built-in'
+        label 'kie-rhel9 && podman && kie-mem24g && !built-in'
     }
     tools {
         maven 'kie-maven-3.9.6'

--- a/.ci/jenkins/Jenkinsfile.prod.nightly
+++ b/.ci/jenkins/Jenkinsfile.prod.nightly
@@ -288,6 +288,7 @@ pipeline {
                             pnpm --version
 
                             export KN_PLUGIN_WORKFLOW__version=${env.ARTIFACTS_VERSION}
+                            export KN_PLUGIN_WORKFLOW__quarkusPlatformGroupId='com.redhat.quarkus.platform'
                             export KN_PLUGIN_WORKFLOW__devModeImageUrl=${env.SWF_DEVMODE_REGISTRY}
                             export KN_PLUGIN_WORKFLOW__builderImage=${env.SWF_BUILDER_REGISTRY}
                             export KIE_TOOLS_BUILD_runTests=false

--- a/.ci/jenkins/Jenkinsfile.prod.nightly
+++ b/.ci/jenkins/Jenkinsfile.prod.nightly
@@ -4,7 +4,7 @@ import org.kie.jenkins.MavenCommand
 
 pipeline {
     agent {
-        label 'kie-rhel8 && podman && kie-mem24g && !built-in'
+        label 'RHEL9 && podman && mem16G && !built-in'
     }
     tools {
         maven 'kie-maven-3.9.6'

--- a/.ci/jenkins/Jenkinsfile.prod.nightly
+++ b/.ci/jenkins/Jenkinsfile.prod.nightly
@@ -4,7 +4,7 @@ import org.kie.jenkins.MavenCommand
 
 pipeline {
     agent {
-        label 'kie-rhel9 && podman && kie-mem24g && !built-in'
+        label 'RHEL9 && podman && mem16G && !built-in'
     }
     tools {
         maven 'kie-maven-3.9.6'

--- a/.ci/jenkins/Jenkinsfile.prod.nightly
+++ b/.ci/jenkins/Jenkinsfile.prod.nightly
@@ -293,7 +293,7 @@ pipeline {
                             export KIE_TOOLS_BUILD_runTests=false
                             export KIE_TOOLS_BUILD_runEndToEndTests=false
                             
-                            pnpm bootstrap -F '@kie-tools/kn-plugin-workflow'
+                            pnpm bootstrap -F '@kie-tools/kn-plugin-workflow...'
                             pnpm -F '@kie-tools/kn-plugin-workflow' build:prod
                         """)
                         // For testing and throughput, if this does not work well, we can still get nightly

--- a/.ci/jenkins/Jenkinsfile.prod.nightly
+++ b/.ci/jenkins/Jenkinsfile.prod.nightly
@@ -288,6 +288,7 @@ pipeline {
                             pnpm --version
 
                             export KN_PLUGIN_WORKFLOW__version=${env.ARTIFACTS_VERSION}
+                            export QUARKUS_PLATFORM_version=${env.QUARKUS_PLATFORM_VERSION}
                             export KN_PLUGIN_WORKFLOW__quarkusPlatformGroupId='com.redhat.quarkus.platform'
                             export KN_PLUGIN_WORKFLOW__devModeImageUrl=${env.SWF_DEVMODE_REGISTRY}
                             export KN_PLUGIN_WORKFLOW__builderImage=${env.SWF_BUILDER_REGISTRY}


### PR DESCRIPTION
Another follow-up on - https://issues.redhat.com/browse/SRVLOGIC-657 

I added pnpm setting to ensure dependcies are bootstraped -  `...`

I added some extra properties to set and ensure correct values in final binaries.

I updated the label to `kie-rhel9` from `kie-rhel8` to ensure correct python is used.