### PR TITLE
SRVLOGIC-725 - increase lock timeout to 300

### DIFF
--- a/.ci/nightly-build-config.yaml
+++ b/.ci/nightly-build-config.yaml
@@ -51,7 +51,7 @@ build:
   - project: kubesmarts/osl-images
     build-command:
       downstream: |
-        export MAVEN_OPTIONS="${{ env.BUILD_MVN_OPTS }} -s ${{ env.PME_MAVEN_SETTINGS_XML }}"
+        export MAVEN_OPTIONS="${{ env.BUILD_MVN_OPTS }} -s ${{ env.PME_MAVEN_SETTINGS_XML }} -Daether.syncContext.named.time=300"
         echo "MAVEN_OPTIONS=${{ env.MAVEN_OPTIONS }}"
         export NIGHTLY="true"
         echo "NIGHTLY=${{ env.NIGHTLY }}"


### PR DESCRIPTION
https://issues.redhat.com/browse/SRVLOGIC-725

osl-images very often ends with lock in quarkus-maven-plugin downloading dependencies, 
so adding 300 secs which is more than 30 seconds by default