### PR TITLE
SRVLOGIC-864: Ensure the git diff exit code is always 0

### DIFF
--- a/.ci/jenkins/Jenkinsfile.prod.nightly
+++ b/.ci/jenkins/Jenkinsfile.prod.nightly
@@ -509,7 +509,7 @@ def buildImage(String imageName, String descriptorFilePath, String nightlyBranch
         sh """sed -i "s/999-SNAPSHOT/${env.ARTIFACTS_VERSION}/g" ${descriptorFile}"""
 
         println "Diff of ${descriptorFile} after replacing branch name and org.kie.kogito.version"
-        sh "git diff --no-index  ${imagesRepository}/${imageFolder}/${descriptorFile} ./${descriptorFile}"
+        sh "git diff --no-index  ${imagesRepository}/${imageFolder}/${descriptorFile} ./${descriptorFile} || true"
 
         println 'Using cekit version'
         util.runWithPythonVirtualEnv('cekit --version', 'cekit')


### PR DESCRIPTION
https://issues.redhat.com/browse/SRVLOGIC-864

I forgot that the `git diff --no-index ...` returns exit code 1 if there are differences so I am adding `|| true` to ensure it is not doing that. We just want to print out the diff for debugging purposes.