### PR TITLE
[SRVLOGIC-888] -  fix after osl cut-off automation run: enable productization maven profile (1/2)

### DIFF
--- a/.ci/pull-request-config.yaml
+++ b/.ci/pull-request-config.yaml
@@ -22,7 +22,7 @@ default:
     current: |
       mvn dependency:tree clean install ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }}
     upstream: |
-      ; mvn dependency:tree clean install -Dquickly ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }}"
+      mvn dependency:tree clean install -Dquickly ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }}"
 
 build:
   - project: kiegroup/drools


### PR DESCRIPTION
**JIRA**  https://redhat.atlassian.net/browse/SRVLOGIC-888

**Related PRs**
- https://github.com/kiegroup/kogito-pipelines/pull/106/changes
- https://github.com/kiegroup/kogito-runtimes/pull/161

**Fix in the OSL cut-off automation** 
https://github.com/jankrystof-ibm/osl_cut_off_automation/commit/5ec03779a616f30b83b17dc825888f34f60e0b81

<details>
<summary>
This is an alternative fix to the https://github.com/kiegroup/kogito-pipelines/pull/106/changes supporting the way the osl cut-off automation should enable the productization profile.  
</summary>

</details>
