### PR TITLE
[SRVLOGIC-963] Remove running remove_modules.sh scripts. 

### DIFF
--- a/.ci/nightly-build-config.yaml
+++ b/.ci/nightly-build-config.yaml
@@ -7,8 +7,6 @@ pre: |
   echo "PME_CMD=${{ env.PME_CMD }}"
   export BUILD_MVN_OPTS="${{ env.BUILD_MVN_OPTS }} -s ${{ env.PME_MAVEN_SETTINGS_XML }} -Dmaven.wagon.http.pool=false -Dhttp.keepAlive=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3"
   echo "BUILD_MVN_OPTS=${{ env.BUILD_MVN_OPTS }}"
-  export REMOVE_MODULES="./productized/remove_modules.sh ./productized/modules"
-  echo "REMOVE_MODULES=${{ env.REMOVE_MODULES }}"
 
 default:
   build-command:
@@ -24,25 +22,25 @@ build:
     build-command:
       upstream: |
         ${{ env.PME_CMD }} ${{ env.PME_ALIGNMENT_PARAMS_kiegroup_drools }}
-        bash -c "set -e ; set -o pipefail ; ${{ env.REMOVE_MODULES }} ; ${{ env.PME_BUILD_SCRIPT_kiegroup_drools }} ${{ env.BUILD_MVN_OPTS }} | tee ${{ env.WORKSPACE }}/drools.maven.log"
+        bash -c "set -e ; set -o pipefail ; ${{ env.PME_BUILD_SCRIPT_kiegroup_drools }} ${{ env.BUILD_MVN_OPTS }} | tee ${{ env.WORKSPACE }}/drools.maven.log"
 
   - project: kiegroup/kogito-runtimes
     build-command:
       current: |
         ${{ env.PME_CMD }} ${{ env.PME_ALIGNMENT_PARAMS_kiegroup_kogito_runtimes }}
-        bash -c "set -e ; set -o pipefail ; ${{ env.REMOVE_MODULES }} ; ${{ env.PME_BUILD_SCRIPT_kiegroup_kogito_runtimes }} ${{ env.BUILD_MVN_OPTS }} | tee ${{ env.WORKSPACE }}/kogito_runtimes.maven.log"
+        bash -c "set -e ; set -o pipefail ; ${{ env.PME_BUILD_SCRIPT_kiegroup_kogito_runtimes }} ${{ env.BUILD_MVN_OPTS }} | tee ${{ env.WORKSPACE }}/kogito_runtimes.maven.log"
 
   - project: kiegroup/kogito-apps
     build-command:
       downstream: |
         ${{ env.PME_CMD }} ${{ env.PME_ALIGNMENT_PARAMS_kiegroup_kogito_apps }}
-        bash -c "set -e ; set -o pipefail ; ${{ env.REMOVE_MODULES }} ; ${{ env.PME_BUILD_SCRIPT_kiegroup_kogito_apps }} ${{ env.BUILD_MVN_OPTS }} | tee ${{ env.WORKSPACE }}/kogito_apps.maven.log"
+        bash -c "set -e ; set -o pipefail ; ${{ env.PME_BUILD_SCRIPT_kiegroup_kogito_apps }} ${{ env.BUILD_MVN_OPTS }} | tee ${{ env.WORKSPACE }}/kogito_apps.maven.log"
 
   - project: kiegroup/kogito-examples
     build-command:
       downstream: |
         ${{ env.PME_CMD }} ${{ env.PME_ALIGNMENT_PARAMS_kiegroup_kogito_examples }}
-        bash -c "set -e ; set -o pipefail ; ${{ env.REMOVE_MODULES }} ; ${{ env.PME_BUILD_SCRIPT_kiegroup_kogito_examples }} ${{ env.BUILD_MVN_OPTS }} | tee ${{ env.WORKSPACE }}/kogito_examples.maven.log"
+        bash -c "set -e ; set -o pipefail ; ${{ env.PME_BUILD_SCRIPT_kiegroup_kogito_examples }} ${{ env.BUILD_MVN_OPTS }} | tee ${{ env.WORKSPACE }}/kogito_examples.maven.log"
 
   - project: kubesmarts/kie-tools
     build-command:

--- a/.ci/pull-request-config-windows.yaml
+++ b/.ci/pull-request-config-windows.yaml
@@ -9,8 +9,6 @@ pre: |
   echo "BUILD_MVN_OPTS_CURRENT=${{ env.BUILD_MVN_OPTS_CURRENT }}"
   echo "QUARKUS_VERSION=${{ env.QUARKUS_VERSION }}"
   echo "ENABLE_DEPLOY=${{ env.ENABLE_DEPLOY }}"
-  export REMOVE_MODULES=".\productized\remove_modules.bat .\productized\modules"
-  echo "REMOVE_MODULES=${{ env.REMOVE_MODULES }}"
 
 default:
   build-command:
@@ -24,37 +22,31 @@ default:
     current: |
       mvn dependency:tree clean install ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }}
     upstream: |
-      ${{ env.REMOVE_MODULES }}; mvn dependency:tree clean install -Dquickly ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }}"
+      mvn dependency:tree clean install -Dquickly ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }}"
 
 build:
   - project: kiegroup/drools
     build-command:
       current: |
-        ${{ env.REMOVE_MODULES }}
         export MVN_CMD=`bash -c "if [ '${{ env.ENABLE_DEPLOY }}' = 'true' ]; then printf 'deploy ${{ env.DEPLOY_MVN_OPTS }} ${{ env.DROOLS_DEPLOY_MVN_OPTS }}'; else printf 'install'; fi"`
         mvn dependency:tree clean ${{ env.MVN_CMD }} ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.DROOLS_BUILD_MVN_OPTS }}
       upstream: |
-        ${{ env.REMOVE_MODULES }}
         mvn dependency:tree clean install -Dquickly ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }} ${{ env.DROOLS_BUILD_MVN_OPTS_UPSTREAM }}
   
   - project: kiegroup/kogito-runtimes
     build-command:
       current: |
-        ${{ env.REMOVE_MODULES }}
         export MVN_CMD=`bash -c "if [ '${{ env.ENABLE_DEPLOY }}' = 'true' ]; then printf 'deploy ${{ env.DEPLOY_MVN_OPTS }} ${{ env.KOGITO_RUNTIMES_DEPLOY_MVN_OPTS }}'; else printf 'install'; fi"`
         mvn dependency:tree clean -Dfull ${{ env.MVN_CMD }} ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.KOGITO_RUNTIMES_BUILD_MVN_OPTS }}
       upstream: |
-        ${{ env.REMOVE_MODULES }} 
         mvn dependency:tree clean install -Dquickly ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }} ${{ env.KOGITO_RUNTIMES_BUILD_MVN_OPTS_UPSTREAM }}
 
   - project: kiegroup/kogito-apps
     build-command: 
       current: |
-        ${{ env.REMOVE_MODULES }}
         export MVN_CMD=`bash -c "if [ '${{ env.ENABLE_DEPLOY }}' = 'true' ]; then printf 'deploy ${{ env.DEPLOY_MVN_OPTS }} ${{ env.KOGITO_APPS_DEPLOY_MVN_OPTS }}'; else printf 'install'; fi"`
         mvn dependency:tree clean ${{ env.MVN_CMD }} ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.KOGITO_APPS_BUILD_MVN_OPTS }}
       upstream: |
-        ${{ env.REMOVE_MODULES }}
         mvn dependency:tree clean install -Dquickly ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }} ${{ env.KOGITO_APPS_BUILD_MVN_OPTS_UPSTREAM }}
 
   - project: kiegroup/kogito-examples
@@ -62,10 +54,8 @@ build:
       # First install the main pom
       # Then build the required submodule pom
       current: |
-        ${{ env.REMOVE_MODULES }}
         export MVN_CMD=`bash -c "if [ '${{ env.ENABLE_DEPLOY }}' = 'true' ]; then printf 'deploy ${{ env.DEPLOY_MVN_OPTS }} ${{ env.KOGITO_EXAMPLES_DEPLOY_MVN_OPTS }}'; else printf 'install'; fi"`
         mvn dependency:tree -pl :kogito-examples clean ${{ env.MVN_CMD }} ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.KOGITO_EXAMPLES_BUILD_MVN_OPTS }}
         mvn dependency:tree -f ${{ env.KOGITO_EXAMPLES_SUBFOLDER_POM }}/pom.xml clean ${{ env.MVN_CMD }} ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.KOGITO_EXAMPLES_BUILD_MVN_OPTS }}
       upstream: |
-        ${{ env.REMOVE_MODULES }} 
         mvn dependency:tree clean install -DskipTests -DskipITs ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }} ${{ env.KOGITO_EXAMPLES_BUILD_MVN_OPTS_UPSTREAM }}

--- a/.ci/pull-request-config.yaml
+++ b/.ci/pull-request-config.yaml
@@ -9,8 +9,6 @@ pre: |
   echo "BUILD_MVN_OPTS_CURRENT=${{ env.BUILD_MVN_OPTS_CURRENT }}"
   echo "QUARKUS_VERSION=${{ env.QUARKUS_VERSION }}"
   echo "ENABLE_DEPLOY=${{ env.ENABLE_DEPLOY }}"
-  export REMOVE_MODULES="./productized/remove_modules.sh ./productized/modules"
-  echo "REMOVE_MODULES=${{ env.REMOVE_MODULES }}"
 
 default:
   build-command:
@@ -24,37 +22,31 @@ default:
     current: |
       mvn dependency:tree clean install ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }}
     upstream: |
-      ${{ env.REMOVE_MODULES }}; mvn dependency:tree clean install -Dquickly ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }}"
+      mvn dependency:tree clean install -Dquickly ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }}"
 
 build:
   - project: kiegroup/drools
     build-command:
       current: |
-        ${{ env.REMOVE_MODULES }}
         export MVN_CMD=`bash -c "if [ '${{ env.ENABLE_DEPLOY }}' = 'true' ]; then printf 'deploy ${{ env.DEPLOY_MVN_OPTS }} ${{ env.DROOLS_DEPLOY_MVN_OPTS }}'; else printf 'install'; fi"`
         mvn dependency:tree clean ${{ env.MVN_CMD }} ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.DROOLS_BUILD_MVN_OPTS }}
       upstream: |
-        ${{ env.REMOVE_MODULES }}
         mvn dependency:tree clean install -Dquickly ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }} ${{ env.DROOLS_BUILD_MVN_OPTS_UPSTREAM }}
   
   - project: kiegroup/kogito-runtimes
     build-command:
       current: |
-        ${{ env.REMOVE_MODULES }}
         export MVN_CMD=`bash -c "if [ '${{ env.ENABLE_DEPLOY }}' = 'true' ]; then printf 'deploy ${{ env.DEPLOY_MVN_OPTS }} ${{ env.KOGITO_RUNTIMES_DEPLOY_MVN_OPTS }}'; else printf 'install'; fi"`
         mvn dependency:tree clean -Dfull ${{ env.MVN_CMD }} ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.KOGITO_RUNTIMES_BUILD_MVN_OPTS }}
       upstream: |
-        ${{ env.REMOVE_MODULES }} 
         mvn dependency:tree clean install -Dquickly ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }} ${{ env.KOGITO_RUNTIMES_BUILD_MVN_OPTS_UPSTREAM }}
 
   - project: kiegroup/kogito-apps
     build-command: 
       current: |
-        ${{ env.REMOVE_MODULES }}
         export MVN_CMD=`bash -c "if [ '${{ env.ENABLE_DEPLOY }}' = 'true' ]; then printf 'deploy ${{ env.DEPLOY_MVN_OPTS }} ${{ env.KOGITO_APPS_DEPLOY_MVN_OPTS }}'; else printf 'install'; fi"`
         mvn dependency:tree clean ${{ env.MVN_CMD }} ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.KOGITO_APPS_BUILD_MVN_OPTS }}
       upstream: |
-        ${{ env.REMOVE_MODULES }}
         mvn dependency:tree clean install -Dquickly ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }} ${{ env.KOGITO_APPS_BUILD_MVN_OPTS_UPSTREAM }}
 
   - project: kiegroup/kogito-examples
@@ -62,10 +54,8 @@ build:
       # First install the main pom
       # Then build the required submodule pom
       current: |
-        ${{ env.REMOVE_MODULES }}
         export MVN_CMD=`bash -c "if [ '${{ env.ENABLE_DEPLOY }}' = 'true' ]; then printf 'deploy ${{ env.DEPLOY_MVN_OPTS }} ${{ env.KOGITO_EXAMPLES_DEPLOY_MVN_OPTS }}'; else printf 'install'; fi"`
         mvn dependency:tree -pl :kogito-examples clean ${{ env.MVN_CMD }} ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.KOGITO_EXAMPLES_BUILD_MVN_OPTS }}
         mvn dependency:tree -f ${{ env.KOGITO_EXAMPLES_SUBFOLDER_POM }}/pom.xml clean ${{ env.MVN_CMD }} ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.KOGITO_EXAMPLES_BUILD_MVN_OPTS }}
       upstream: |
-        ${{ env.REMOVE_MODULES }} 
         mvn dependency:tree clean install -DskipTests -DskipITs ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }} ${{ env.KOGITO_EXAMPLES_BUILD_MVN_OPTS_UPSTREAM }}


### PR DESCRIPTION
Required for SonataFlow snapshot publishing changes: https://redhat.atlassian.net/browse/SRVLOGIC-963

In the PRs for SonataFlow snapshots, I ran those scripts, so the modules should be by default removed from the pom.xmls in the repositories. 