### PR TITLE
[SRVLOGIC-984] Export MAVEN_ARGS for kie-tools in nightly build.

### DIFF
--- a/.ci/nightly-build-config.yaml
+++ b/.ci/nightly-build-config.yaml
@@ -46,6 +46,7 @@ build:
     build-command:
       downstream: |
         ${{ env.PME_CMD }} ${{ env.PME_ALIGNMENT_PARAMS_kubesmarts_kie_tools }}
+        export MAVEN_ARGS=${{ env.BUILD_MVN_OPTS }}
         bash -c "set -o pipefail ; ${{ env.PME_BUILD_SCRIPT_kubesmarts_kie_tools }} ${{ env.BUILD_MVN_OPTS }} | tee ${{ env.WORKSPACE }}/kie_tools.maven.log"
 
   - project: kubesmarts/osl-images


### PR DESCRIPTION
This exports MAVEN_ARGS for kie-tools build, so all mvn invocation use the proper build arguments (e.g. settings.xml).