### PR TITLE
[SRVLOGIC-707] Use empty map instead of empty list as artifacts for bundle. 

### DIFF
--- a/.ci/jenkins/Jenkinsfile.prod.nightly
+++ b/.ci/jenkins/Jenkinsfile.prod.nightly
@@ -296,7 +296,7 @@ pipeline {
 
                             def descriptorFilePath = 'images-dist/logic-operator-bundle-image.yaml'
                             // There are no artifact overrides for the bundle image.
-                            def artifacts = [];
+                            def artifacts = [:];
                             env.OPERATOR_BUNDLE_REGISTRY = buildImage(env.OPERATOR_BUNDLE, descriptorFilePath, env.NIGHTLY_BRANCH_NAME, artifacts, env.IMAGES_REPOSITORY_PATH)
                         }
                     }


### PR DESCRIPTION
Ticket: https://redhat.atlassian.net/browse/SRVLOGIC-707

Fixed typo - used empty list instead of required empty map as artifacts parameter for the build. 