### PR TITLE
[SRVLOGIC-707] Do not pin digests of images as it is scratch build.

### DIFF
--- a/.ci/jenkins/Jenkinsfile.prod.nightly
+++ b/.ci/jenkins/Jenkinsfile.prod.nightly
@@ -295,6 +295,9 @@ pipeline {
                             sleep(Integer.parseInt(env.SLEEP_TIME) * 8)
 
                             def descriptorFilePath = 'images-dist/logic-operator-bundle-image.yaml'
+                            // Disable digest pinning for nightly scratch builds — OSBS cannot resolve
+                            // tags for images that were built as scratch in the same pipeline run.
+                            sh """sed -i 's/enable_digest_pinning: true/enable_digest_pinning: false/g' ${env.IMAGES_REPOSITORY_PATH}/${descriptorFilePath}"""
                             // There are no artifact overrides for the bundle image.
                             def artifacts = [:];
                             env.OPERATOR_BUNDLE_REGISTRY = buildImage(env.OPERATOR_BUNDLE, descriptorFilePath, env.NIGHTLY_BRANCH_NAME, artifacts, env.IMAGES_REPOSITORY_PATH)


### PR DESCRIPTION
Ticket: https://redhat.atlassian.net/browse/SRVLOGIC-707

When OSBS builds the bundle, it tries to pin the related images digests. However during nightly, we do scratch builds of images, not public builds. That means that the pinning cannot find the images. The digests pinning shouldn't be done for the scratch builds. This PR modifies the yaml definition file for the bundle to disable the pinning before the build is started. 